### PR TITLE
Update apg-home.html

### DIFF
--- a/content/apg-home.html
+++ b/content/apg-home.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ARIA オーサリング プラクティス ガイド</title>
+    <title>ARIA Authoring Practices Guide</title>
     <style>
       img {
         display: block;
@@ -15,82 +15,82 @@
   </head>
   <body>
     <div id="top-card">
-      <aside class="trnote" style="border: 1px solid #000; padding: 0.2em 1em;">
-        <p>この文書は、<a href="https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190207/">2019 年 2 月 7 日付けの W3C ワーキンググループノートWAI-ARIA Authoring Practices 1.1</a><b style="color : red ; font-size: 1.4em;">（ここに作業単位（管理されてるファイル単位）で、翻訳元のコミット番号を記す？ by 今井）</b>について、<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC) の翻訳ワーキンググループ</a>の責任において翻訳・公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、WAIC翻訳ワーキンググループにて対応いたしますので、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fNOTE-wai-aria-practices-1.1-20190207" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
-      </aside>
-      <h1>ARIA オーサリング プラクティス ガイド (APG) ホーム</h1>
+      <h1>ARIA Authoring Practices Guide (APG) Home</h1>
       <p>
-        Accessible Rich Internet Application（ARIA）仕様で定義されたアクセシビリティ・セマンティクスを使用して、アクセシブルなWebエクスペリエンスを作成する方法を学びます。このガイドでは、一般的なデザインパターンとウィジェットにアクセシビリティ・セマンティクスを適用する方法について説明します。デザインパターンと機能的な例を提供し、基本的なプラクティスに関する詳細なガイダンスで補完しています。
+        Learn to use the accessibility semantics defined by the Accessible Rich Internet Application (ARIA) specification to create accessible web experiences.
+        This guide describes how to apply accessibility semantics to common design patterns and widgets.
+        It provides design patterns and functional examples complemented by in-depth guidance for fundamental practices.
       </p>
-      <a href="patterns/patterns.html">パターンを見る</a>
+      <a href="patterns/patterns.html">View Patterns</a>
       <img alt="A laptop screen fills with an accessibility icon and emits a checkmark." src="images/index-1.svg">
     </div>
     <div id="resources">
-      <h2>APG リソース</h2>
-      <p>ウェブをアクセシブルにするために役立つビルディングブロック</p>
+      <h2>APG Resources</h2>
+      <p>Building blocks that help you make the web accessible</p>
       <ul>
         <li>
-          <h3>デザインパターンとその例</h3>
+          <h3>Design Patterns and Examples</h3>
           <p>
-            ARIAのロール、ステート、プロパティを使用し、キーボードサポートを実装することで、アクセシブルなWebコンポーネントやウィジェットを作成する方法を紹介します。各パターンを実装する1つまたは複数の方法を、機能的な例で説明します。
+            Learn how to make accessible web components and widgets with ARIA roles, states and properties and by implementing keyboard support.
+            One or more ways of implementing each pattern is demonstrated with a functional example.
           </p>
-          <a href="patterns/patterns.html" aria-label="Learn more about APG patterns and examples">詳細はこちら</a>
+          <a href="patterns/patterns.html" aria-label="Learn more about APG patterns and examples">Learn More</a>
           <img alt="A menagerie of widgets." src="images/index-2.svg">
         </li>
         <li>
-          <h3>ARIAランドマークを使う</h3>
-          <p>HTMLのセクショニング要素とARIAのランドマークロールを使用して、支援技術ユーザーがページのレイアウトの意味を簡単に理解できるようにする方法を紹介します。</p>
-          <a href="practices/landmark-regions/landmark-regions-practice.html" aria-label="Learn more about ARIA landmarks">詳細はこちら</a>
+          <h3>Use ARIA Landmarks</h3>
+          <p>Learn how to use HTML sectioning elements and ARIA landmark roles to make it easy for assistive technology users to understand the meaning of the layout of a page.</p>
+          <a href="practices/landmark-regions/landmark-regions-practice.html" aria-label="Learn more about ARIA landmarks">Learn More</a>
           <img alt="A document flies apart into chunks." src="images/index-3.svg">
         </li>
         <li>
-          <h3>アクセシブルな名称と説明文の提供</h3>
-          <p>要素にアクセシブルな名前をつけ、必要に応じてアクセシブルな記述をすることは、アクセシブルなウェブ体験を開発する際に作者が負う最も重要な責任の1つです。</p>
-          <a href="practices/names-and-descriptions/names-and-descriptions-practice.html" aria-label="Learn more about accessible names and descriptions">詳細はこちら</a>
+          <h3>Providing Accessible Names and Descriptions</h3>
+          <p>Providing elements with accessible names and, where appropriate, accessible descriptions is one of the most important responsibilities authors have when developing accessible web experiences.</p>
+          <a href="practices/names-and-descriptions/names-and-descriptions-practice.html" aria-label="Learn more about accessible names and descriptions">Learn More</a>
           <img alt="Indicators delve inside a document." src="images/index-4.svg">
         </li>
         <li>
-          <h3>そして、さらに多くのことを...。</h3>
-          <p>その他、アクセシビリティ・セマンティックの正しい使い方、キーボード・インターフェースの開発などに関する基本的なプラクティスについて学びます。</p>
-          <a class="button-link" href="practices/practices.html" aria-label="Learn more about APG practices">詳細はこちら</a>
+          <h3>And So Much More...</h3>
+          <p>Learn about other fundamental practices related to correctly using accessibility semantics, developing keyboard interfaces, and more.</p>
+          <a class="button-link" href="practices/practices.html" aria-label="Learn more about APG practices">Learn More</a>
           <img alt="A box with an accessibility label is chock full of widgets and document bits." src="images/index-5.svg">
         </li>
       </ul>
     </div>
 
     <div id="collaboration">
-      <h2 class="collaboration-h2">参加する</h2>
+      <h2 class="collaboration-h2">Get Involved</h2>
       <p class="collaboration-p">
-        APGタスクフォースは、APGの有用性と品質を継続的に向上させるために、幅広いコミュニティの代表と参加に依存しています。
-        アクセシブルな体験の開発を促進するために、さまざまな方法で参加することができます。
+        The APG Task Force relies on broad community representation and participation to continuously improve the usefulness and quality of the APG.
+        There are a variety of ways you can get involved and help promote development of accessible experiences.
       </p>
       <ul>
         <li>
-          <h3>タスクフォースに参加する</h3>
+          <h3>Join the Task Force</h3>
           <p>
-            APGタスクフォースに参加するには、まずW3C ARIAワーキンググループに参加する必要があります。
-            参加者は、タスクフォースの作業に積極的に貢献することが期待されます。
+            To join the APG Task Force, individuals need to first join the W3C ARIA Working Group.
+            Participants are expected to actively contribute to the work of the task force.
           </p>
-          <a rel="noopener noreferrer" target="_blank" href="https://www.w3.org/WAI/ARIA/task-forces/practices/">タスクフォースの活動内容や参加方法について詳しくはこちら</a>
+          <a rel="noopener noreferrer" target="_blank" href="https://www.w3.org/WAI/ARIA/task-forces/practices/">Learn more about the work of the task force and how to join</a>
           <img alt="An icon showing three nodes connecting." src="images/index-6.svg">
         </li>
         <li>
-          <h3>GitHubで貢献する</h3>
+          <h3>Contribute via GitHub</h3>
           <p>
-            多くの貴重な貢献は、私たちのGitHubリポジトリで興味のある問題を見つけたり提起したりして、GitHubプルリクエストで変更案を提出する人々によって行われています。
-            この方法を選択する場合は、リポジトリへの貢献とコードの品質を維持するためのガイドラインを学ぶことから始めてください。
+            Many valuable contributions are made by people who find or raise issues of interest in our GitHub repository and then submit proposed changes via a GitHub pull request.
+            If you choose this path, please start by studying our guidelines for contributing to the repository and maintaining code quality.
           </p>
-          <a rel="noopener noreferrer" target="_blank" href="https://github.com/w3c/aria-practices">GitHubのリポジトリでReadMeを見る</a>
+          <a rel="noopener noreferrer" target="_blank" href="https://github.com/w3c/aria-practices">View ReadMe in the GitHub repository</a>
           <img alt="An icon showing two human shapes carrying a burden." src="images/index-7.svg">
         </li>
         <li>
-          <h3>メーリングリスト</h3>
+          <h3>Mailing Lists</h3>
           <p>
-            APGタスクフォースは、公開されているaria-practicesメーリングリストを電子メールでの議論に使用しています。
-            会議の告知、議題、議事録へのリンクはメーリングリストに送信されます。
-            GitHubのissueはAPGのコンテンツを議論するのに適した場所ですが、APGタスクフォースと電子メールでのコミュニケーションを希望する人はメーリングリストを利用することができます。
+            The APG Task Force uses the public aria-practices mailing list for email discussion.
+            Meeting announcements, agendas, and links to minutes are sent to the mailing list.
+            While GitHub issues are the preferred place to discuss APG content, the mailing list is available to anyone who would prefer to communicate with the APG Task Force via email.
           </p>
-          <p><a rel="noopener noreferrer" target="_blank" href="https://lists.w3.org/Archives/Public/public-aria-practices/">aria-practicesメーリングリストアーカイブを見る</a></p>
+          <p><a rel="noopener noreferrer" target="_blank" href="https://lists.w3.org/Archives/Public/public-aria-practices/">View the aria-practices mailing list archive</a></p>
           <img alt="A notification bell icon appears over an email icon." src="images/index-8.svg">
         </li>
       </ul>

--- a/content/apg-home.html
+++ b/content/apg-home.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ARIA Authoring Practices Guide</title>
+    <title>ARIA オーサリング プラクティス ガイド</title>
     <style>
       img {
         display: block;
@@ -15,82 +15,82 @@
   </head>
   <body>
     <div id="top-card">
-      <h1>ARIA Authoring Practices Guide (APG) Home</h1>
+      <aside class="trnote" style="border: 1px solid #000; padding: 0.2em 1em;">
+        <p>この文書は、<a href="https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190207/">2019 年 2 月 7 日付けの W3C ワーキンググループノートWAI-ARIA Authoring Practices 1.1</a><b style="color : red ; font-size: 1.4em;">（ここに作業単位（管理されてるファイル単位）で、翻訳元のコミット番号を記す？ by 今井）</b>について、<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC) の翻訳ワーキンググループ</a>の責任において翻訳・公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、WAIC翻訳ワーキンググループにて対応いたしますので、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fNOTE-wai-aria-practices-1.1-20190207" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
+      </aside>
+      <h1>ARIA オーサリング プラクティス ガイド (APG) ホーム</h1>
       <p>
-        Learn to use the accessibility semantics defined by the Accessible Rich Internet Application (ARIA) specification to create accessible web experiences.
-        This guide describes how to apply accessibility semantics to common design patterns and widgets.
-        It provides design patterns and functional examples complemented by in-depth guidance for fundamental practices.
+        Accessible Rich Internet Application（ARIA）仕様で定義されたアクセシビリティ・セマンティクスを使用して、アクセシブルなWebエクスペリエンスを作成する方法を学びます。このガイドでは、一般的なデザインパターンとウィジェットにアクセシビリティ・セマンティクスを適用する方法について説明します。デザインパターンと機能的な例を提供し、基本的なプラクティスに関する詳細なガイダンスで補完しています。
       </p>
-      <a href="patterns/patterns.html">View Patterns</a>
+      <a href="patterns/patterns.html">パターンを見る</a>
       <img alt="A laptop screen fills with an accessibility icon and emits a checkmark." src="images/index-1.svg">
     </div>
     <div id="resources">
-      <h2>APG Resources</h2>
-      <p>Building blocks that help you make the web accessible</p>
+      <h2>APG リソース</h2>
+      <p>ウェブをアクセシブルにするために役立つビルディングブロック</p>
       <ul>
         <li>
-          <h3>Design Patterns and Examples</h3>
+          <h3>デザインパターンとその例</h3>
           <p>
-            Learn how to make accessible web components and widgets with ARIA roles, states and properties and by implementing keyboard support.
-            One or more ways of implementing each pattern is demonstrated with a functional example.
+            ARIAのロール、ステート、プロパティを使用し、キーボードサポートを実装することで、アクセシブルなWebコンポーネントやウィジェットを作成する方法を紹介します。各パターンを実装する1つまたは複数の方法を、機能的な例で説明します。
           </p>
-          <a href="patterns/patterns.html" aria-label="Learn more about APG patterns and examples">Learn More</a>
+          <a href="patterns/patterns.html" aria-label="Learn more about APG patterns and examples">詳細はこちら</a>
           <img alt="A menagerie of widgets." src="images/index-2.svg">
         </li>
         <li>
-          <h3>Use ARIA Landmarks</h3>
-          <p>Learn how to use HTML sectioning elements and ARIA landmark roles to make it easy for assistive technology users to understand the meaning of the layout of a page.</p>
-          <a href="practices/landmark-regions/landmark-regions-practice.html" aria-label="Learn more about ARIA landmarks">Learn More</a>
+          <h3>ARIAランドマークを使う</h3>
+          <p>HTMLのセクショニング要素とARIAのランドマークロールを使用して、支援技術ユーザーがページのレイアウトの意味を簡単に理解できるようにする方法を紹介します。</p>
+          <a href="practices/landmark-regions/landmark-regions-practice.html" aria-label="Learn more about ARIA landmarks">詳細はこちら</a>
           <img alt="A document flies apart into chunks." src="images/index-3.svg">
         </li>
         <li>
-          <h3>Providing Accessible Names and Descriptions</h3>
-          <p>Providing elements with accessible names and, where appropriate, accessible descriptions is one of the most important responsibilities authors have when developing accessible web experiences.</p>
-          <a href="practices/names-and-descriptions/names-and-descriptions-practice.html" aria-label="Learn more about accessible names and descriptions">Learn More</a>
+          <h3>アクセシブルな名称と説明文の提供</h3>
+          <p>要素にアクセシブルな名前をつけ、必要に応じてアクセシブルな記述をすることは、アクセシブルなウェブ体験を開発する際に作者が負う最も重要な責任の1つです。</p>
+          <a href="practices/names-and-descriptions/names-and-descriptions-practice.html" aria-label="Learn more about accessible names and descriptions">詳細はこちら</a>
           <img alt="Indicators delve inside a document." src="images/index-4.svg">
         </li>
         <li>
-          <h3>And So Much More...</h3>
-          <p>Learn about other fundamental practices related to correctly using accessibility semantics, developing keyboard interfaces, and more.</p>
-          <a class="button-link" href="practices/practices.html" aria-label="Learn more about APG practices">Learn More</a>
+          <h3>そして、さらに多くのことを...。</h3>
+          <p>その他、アクセシビリティ・セマンティックの正しい使い方、キーボード・インターフェースの開発などに関する基本的なプラクティスについて学びます。</p>
+          <a class="button-link" href="practices/practices.html" aria-label="Learn more about APG practices">詳細はこちら</a>
           <img alt="A box with an accessibility label is chock full of widgets and document bits." src="images/index-5.svg">
         </li>
       </ul>
     </div>
 
     <div id="collaboration">
-      <h2 class="collaboration-h2">Get Involved</h2>
+      <h2 class="collaboration-h2">参加する</h2>
       <p class="collaboration-p">
-        The APG Task Force relies on broad community representation and participation to continuously improve the usefulness and quality of the APG.
-        There are a variety of ways you can get involved and help promote development of accessible experiences.
+        APGタスクフォースは、APGの有用性と品質を継続的に向上させるために、幅広いコミュニティの代表と参加に依存しています。
+        アクセシブルな体験の開発を促進するために、さまざまな方法で参加することができます。
       </p>
       <ul>
         <li>
-          <h3>Join the Task Force</h3>
+          <h3>タスクフォースに参加する</h3>
           <p>
-            To join the APG Task Force, individuals need to first join the W3C ARIA Working Group.
-            Participants are expected to actively contribute to the work of the task force.
+            APGタスクフォースに参加するには、まずW3C ARIAワーキンググループに参加する必要があります。
+            参加者は、タスクフォースの作業に積極的に貢献することが期待されます。
           </p>
-          <a rel="noopener noreferrer" target="_blank" href="https://www.w3.org/WAI/ARIA/task-forces/practices/">Learn more about the work of the task force and how to join</a>
+          <a rel="noopener noreferrer" target="_blank" href="https://www.w3.org/WAI/ARIA/task-forces/practices/">タスクフォースの活動内容や参加方法について詳しくはこちら</a>
           <img alt="An icon showing three nodes connecting." src="images/index-6.svg">
         </li>
         <li>
-          <h3>Contribute via GitHub</h3>
+          <h3>GitHubで貢献する</h3>
           <p>
-            Many valuable contributions are made by people who find or raise issues of interest in our GitHub repository and then submit proposed changes via a GitHub pull request.
-            If you choose this path, please start by studying our guidelines for contributing to the repository and maintaining code quality.
+            多くの貴重な貢献は、私たちのGitHubリポジトリで興味のある問題を見つけたり提起したりして、GitHubプルリクエストで変更案を提出する人々によって行われています。
+            この方法を選択する場合は、リポジトリへの貢献とコードの品質を維持するためのガイドラインを学ぶことから始めてください。
           </p>
-          <a rel="noopener noreferrer" target="_blank" href="https://github.com/w3c/aria-practices">View ReadMe in the GitHub repository</a>
+          <a rel="noopener noreferrer" target="_blank" href="https://github.com/w3c/aria-practices">GitHubのリポジトリでReadMeを見る</a>
           <img alt="An icon showing two human shapes carrying a burden." src="images/index-7.svg">
         </li>
         <li>
-          <h3>Mailing Lists</h3>
+          <h3>メーリングリスト</h3>
           <p>
-            The APG Task Force uses the public aria-practices mailing list for email discussion.
-            Meeting announcements, agendas, and links to minutes are sent to the mailing list.
-            While GitHub issues are the preferred place to discuss APG content, the mailing list is available to anyone who would prefer to communicate with the APG Task Force via email.
+            APGタスクフォースは、公開されているaria-practicesメーリングリストを電子メールでの議論に使用しています。
+            会議の告知、議題、議事録へのリンクはメーリングリストに送信されます。
+            GitHubのissueはAPGのコンテンツを議論するのに適した場所ですが、APGタスクフォースと電子メールでのコミュニケーションを希望する人はメーリングリストを利用することができます。
           </p>
-          <p><a rel="noopener noreferrer" target="_blank" href="https://lists.w3.org/Archives/Public/public-aria-practices/">View the aria-practices mailing list archive</a></p>
+          <p><a rel="noopener noreferrer" target="_blank" href="https://lists.w3.org/Archives/Public/public-aria-practices/">aria-practicesメーリングリストアーカイブを見る</a></p>
           <img alt="A notification bell icon appears over an email icon." src="images/index-8.svg">
         </li>
       </ul>


### PR DESCRIPTION
トップページの更新です。

- `<html lang="en">`は`<html lang="ja">`にしたほうが良い？
- 「オーサリング・プラクティス ガイド」？それとも「オーサリング プラクティス ガイド」？
- 「バージョン管理」は「翻訳元のコミット番号を記す」とのことだが、「コミット番号」が何を参照すればよいのかわからず、未記載。
- 文書の冒頭に「WAICによる日本語訳である旨の注釈」を記載。
