### PR TITLE
examplesディレクトリが更新された際に走るスクリプトを停止

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,20 +67,6 @@
     "*.css": "stylelint --fix",
     "*.js": [
       "eslint --fix"
-    ],
-    "content/patterns/**/examples/*.html": [
-      "npm run reference-tables",
-      "git add content/index/index.html",
-      "npm run coverage-report",
-      "git add content/about/coverage-and-quality/"
-    ],
-    "scripts/reference-tables.*": [
-      "npm run reference-tables",
-      "git add content/index/index.html"
-    ],
-    "scripts/coverage-report.*": [
-      "npm run coverage-report",
-      "git add content/about/coverage-and-quality/"
     ]
   },
   "ava": {


### PR DESCRIPTION
## 概要
SSIA

## なぜ
examples配下のhtmlをコミットするたびにlint-stagedによってスクリプトが走ります。
一方はindex.htmlを現在のexamples配下のhtmlのタイトルで書き換えてコミットします。
一方はなにかのカバレッジを出力します。

前者は #156 で翻訳したファイルを英語に戻してしまい、日本語訳において害となってしまうスクリプトです。
後者は害はないですが、日本語訳にあたっては不要です。

ということで、まとめて停止してしまいます。