### PR TITLE
ci: 本家 w3c/aria-practices を月次で取り込む workflow を追加

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,140 @@
+name: Sync from w3c/aria-practices
+
+on:
+  schedule:
+    - cron: '0 15 1 * *'   # 毎月 1 日 15:00 UTC（JST 2 日 0:00）
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write           # ラベル作成に必要
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      # --- ガード 1: 既存の open な sync PR があれば何もしない ---
+      - name: Guard - skip if open sync PR exists
+        id: guard_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --label upstream-sync \
+            --state open \
+            --json number --jq 'length')
+          echo "open=$OPEN" >> "$GITHUB_OUTPUT"
+          if [ "$OPEN" -gt 0 ]; then
+            echo "::notice::Open sync PR exists. Skipping this run."
+          fi
+
+      - name: Checkout waic-main
+        if: steps.guard_pr.outputs.open == '0'
+        uses: actions/checkout@v4
+        with:
+          ref: waic-main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        if: steps.guard_pr.outputs.open == '0'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote and fetch
+        if: steps.guard_pr.outputs.open == '0'
+        run: |
+          git remote add upstream https://github.com/w3c/aria-practices.git
+          git fetch upstream main --no-tags
+
+      # --- ガード 2: 取り込むべき新規コミットが無ければ何もしない ---
+      - name: Guard - skip if no new upstream commits
+        if: steps.guard_pr.outputs.open == '0'
+        id: guard_commits
+        run: |
+          COUNT=$(git rev-list --count HEAD..upstream/main)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" = "0" ]; then
+            echo "::notice::No new upstream commits. Skipping."
+          fi
+
+      - name: Prepare sync branch
+        if: steps.guard_pr.outputs.open == '0' && steps.guard_commits.outputs.count != '0'
+        id: branch
+        run: |
+          MONTH=$(date -u +%Y%m)
+          BRANCH="sync/upstream-${MONTH}"
+          git checkout -B "$BRANCH"
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "short=$(git rev-parse --short upstream/main)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse upstream/main)" >> "$GITHUB_OUTPUT"
+
+      - name: Merge upstream (allow conflicts)
+        if: steps.guard_pr.outputs.open == '0' && steps.guard_commits.outputs.count != '0'
+        id: merge
+        run: |
+          set +e
+          git merge --no-ff --no-edit upstream/main
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -ne 0 ]; then
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            # コンフリクト一覧を PR 本文用に保存
+            git diff --name-only --diff-filter=U > /tmp/conflicts.txt
+            git add -A
+            # lint-staged はコンフリクトマーカー入り HTML を通せないので --no-verify
+            git -c core.editor=true commit --no-verify \
+              -m "chore: merge upstream w3c/main (CONFLICTS — please resolve)"
+          else
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+            : > /tmp/conflicts.txt
+          fi
+
+      - name: Ensure labels exist
+        if: steps.guard_pr.outputs.open == '0' && steps.guard_commits.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create upstream-sync --color BFD4F2 --description "Automated upstream sync PR" 2>/dev/null || true
+          gh label create conflicts     --color D93F0B --description "Has unresolved merge conflicts" 2>/dev/null || true
+          gh label create clean         --color 0E8A16 --description "Clean merge, no conflicts" 2>/dev/null || true
+
+      - name: Push branch and open draft PR
+        if: steps.guard_pr.outputs.open == '0' && steps.guard_commits.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push -u origin "${{ steps.branch.outputs.name }}"
+
+          STATE_LABEL=clean
+          [ "${{ steps.merge.outputs.conflict }}" = "true" ] && STATE_LABEL=conflicts
+
+          {
+            echo "本家 \`w3c/aria-practices\` の最新を \`waic-main\` に取り込む自動 PR です。"
+            echo ""
+            echo "- upstream HEAD: \`${{ steps.branch.outputs.sha }}\`"
+            echo "- 取り込みコミット数: ${{ steps.guard_commits.outputs.count }}"
+            echo "- コンフリクト: **${{ steps.merge.outputs.conflict }}**"
+            echo ""
+            if [ -s /tmp/conflicts.txt ]; then
+              echo "### コンフリクト発生ファイル"
+              echo ""
+              while read -r f; do echo "- \`$f\`"; done < /tmp/conflicts.txt
+              echo ""
+              echo "コンフリクトマーカーがそのままコミットされています。手元で解消後 force-push してください。"
+            else
+              echo "コンフリクトなし。CI 通過後そのままマージ可能です。"
+            fi
+          } > /tmp/pr_body.md
+
+          gh pr create \
+            --base waic-main \
+            --head "${{ steps.branch.outputs.name }}" \
+            --title "chore(sync): upstream w3c/aria-practices @ ${{ steps.branch.outputs.short }}" \
+            --body-file /tmp/pr_body.md \
+            --label upstream-sync \
+            --label "$STATE_LABEL" \
+            --draft


### PR DESCRIPTION
## 概要

本家 [`w3c/aria-practices`](https://github.com/w3c/aria-practices) の更新を **月次** で取り込む GitHub Actions workflow を追加します。

関連: #164 （手動 merge の試行 PR）。本家との差分が約 21 ヶ月で 77 コミット溜まっていたため、今後は自動化で発見遅延を防ぐ目的です。

## 仕様

| 項目 | 内容 |
|---|---|
| 起動 | `cron: '0 15 1 * *'` （毎月 1 日 JST 0:00）+ `workflow_dispatch` |
| ガード 1 | `upstream-sync` ラベル付きの **open PR が既にあれば skip**（積み上がり防止） |
| ガード 2 | upstream に **新規コミットが無ければ skip**（空 PR 防止） |
| merge 戦略 | `git merge --no-ff --no-edit upstream/main`。コンフリクトはマーカーごと `--no-verify` でコミット |
| ラベル | `upstream-sync` + 結果に応じて `clean` / `conflicts` を自動付与 |
| 認証 | `secrets.GITHUB_TOKEN`（PAT 不要） |
| PR 形態 | **draft** で作成、本文にコンフリクトファイル一覧を自動挿入 |

## 既知の制約

- `GITHUB_TOKEN` で作成された PR からは派生 workflow（lint 等）が起動しない GitHub 仕様あり。clean merge で自動 CI を回したい段階になったら、`SYNC_TOKEN` という名前で `repo` 権限の PAT を Secret に登録し、checkout / push / pr create の token をそれに差し替える運用に変更してください。
- 月次（1 回／月）で運用してみて、コンフリクトが重くなる傾向が出たら `cron: '0 15 1,15 * *'` で隔週に切り替え可能。

## 動作確認

マージ後の最初の月初に自動起動しますが、すぐ試したい場合は Actions タブから **Run workflow** で手動実行できます。

## 翻訳作業フローへの影響

WAIC の作業手順（[wiki](https://github.com/waic/aria-practices/wiki/%E4%BD%9C%E6%A5%AD%E6%89%8B%E9%A0%86)）に「本家追従用 PR が立った場合の取り扱い」を追記すると、メンバー間で運用が揃いやすくなります（本 PR の範囲外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)